### PR TITLE
non chunked algorithm using no regexps for faster run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,35 @@
+[![GoDoc](https://godoc.org/facette.io/natsort?status.svg)](https://godoc.org/facette.io/natsort)
+
+
 # natsort: natural strings sorting in Go
 
-This is an implementation of the "Alphanum Algorithm" by [Dave Koelle][0] in Go.
+This is NOT an implementation of the "Alphanum Algorithm" by [Dave Koelle][0] in Go, but something slightly better.
 
-[![GoDoc](https://godoc.org/facette.io/natsort?status.svg)](https://godoc.org/facette.io/natsort)
+## Benchmark
+
+This was modified to use something else than chunks and Dave Koelle's algorithm. Not only the previous version used regular expressions to detect numbers, but it would also allocate extra memory to store the parsed values and was not optimized at all. This version is more optimized.
+
+### Before
+
+```
+goos: linux
+goarch: amd64
+pkg: github.com/MagicalTux/natsort
+cpu: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz
+BenchmarkSort1-12    	    6136	    300245 ns/op
+PASS
+```
+
+### After
+
+```
+goos: linux
+goarch: amd64
+pkg: github.com/MagicalTux/natsort
+cpu: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz
+BenchmarkSort1-12    	  606818	      2013 ns/op
+PASS
+```
 
 ## Usage
 

--- a/natsort_test.go
+++ b/natsort_test.go
@@ -8,6 +8,7 @@ import (
 
 var testList = []string{
 	"1000X Radonius Maximus",
+	"000050X Radonius",
 	"10X Radonius",
 	"200X Radonius",
 	"20X Radonius",
@@ -51,6 +52,7 @@ func Test_Sort1(t *testing.T) {
 		"20X Radonius Prime",
 		"30X Radonius",
 		"40X Radonius",
+		"000050X Radonius",
 		"200X Radonius",
 		"1000X Radonius Maximus",
 		"Allegia 6R Clasteron",


### PR DESCRIPTION
This is a re-creation of https://github.com/facette/natsort/pull/2 with a separate source branch to avoid polluting the merge requests with stuff I've pushed to master on my fork.

I've modified this algorithm to be faster by not using regexps (too many Go projects tend to rely on regexp too quickly, losing a lot in performances) and also to limit allocations of heap memory as much as possible.

I've edited the README with a comparative benchmark, here is it:

Before:

```
goos: linux
goarch: amd64
pkg: github.com/MagicalTux/natsort
cpu: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz
BenchmarkSort1-12    	    6136	    300245 ns/op
PASS
```

After:

```
goos: linux
goarch: amd64
pkg: github.com/MagicalTux/natsort
cpu: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz
BenchmarkSort1-12    	  606818	      2013 ns/op
PASS
```

I've edited the tests to add one edge case (many zeroes prefixing a number), and all tests run OK, but I'd feel safer having more tests on this.